### PR TITLE
make driver private, improve godoc

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # sqltracing
+[![Go Report Card](https://goreportcard.com/badge/github.com/simplesurance/sqltracing)](https://goreportcard.com/report/github.com/simplesurance/sqltracing)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/simplesurance/sqltracing)
 
 sqltracing is a Go package for tracing database operations via an OpenTracing
 tracer.
 It can wrap any `driver.Driver` compatible SQL driver.
 
-## Example
+
+## Documentation
+
+[Go Package Documentation](https://pkg.go.dev/github.com/simplesurance/sqltracing)
+
+### Example
 
 See [example_test.go](example_test.go)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # sqltracing
+![CI](https://github.com/simplesurance/sqltracing/actions/workflows/go.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/simplesurance/sqltracing)](https://goreportcard.com/report/github.com/simplesurance/sqltracing)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/simplesurance/sqltracing)
 

--- a/driver.go
+++ b/driver.go
@@ -1,4 +1,4 @@
-// Package sqltracing provides a SQL driver wrapped to record trace for db
+// Package sqltracing provides a SQL driver wrapper to record trace for db
 // operations.
 package sqltracing
 
@@ -17,8 +17,10 @@ type tracedDriver struct {
 	tracer      Tracer
 }
 
-// NewDriver returns a new driver that traces all operations and forwards them
-// to the passed driver.
+// NewDriver returns a driver that wraps the passed driver and records traces
+// for it's operations.
+// Compatible tracer implementations can be found in the package
+// sqltracing/tracing/.
 func NewDriver(driver driver.Driver, tracer Tracer, opts ...Opt) driver.Driver {
 	tracingDriver := tracedDriver{
 		excludedOps: map[SQLOp]struct{}{},

--- a/ops.go
+++ b/ops.go
@@ -1,9 +1,11 @@
 package sqltracing
 
 // SQLOp is the name of an sql operation.
-// It can be passed to the WithOpsExcluded() option
 type SQLOp string
 
+// Defines the names of SQL operations.
+// These constants are used to name the tracing spans for the related SQL
+// operations.
 const (
 	OpSQLPrepare    SQLOp = "sql-prepare"
 	OpSQLConnExec   SQLOp = "sql-conn-exec"

--- a/opts.go
+++ b/opts.go
@@ -1,10 +1,10 @@
 package sqltracing
 
-type Opt func(*Driver)
+type Opt func(*tracedDriver)
 
 // WithOpsExcluded defines operations for which no traces are recorded.
 func WithOpsExcluded(ops ...SQLOp) Opt {
-	return func(drv *Driver) {
+	return func(drv *tracedDriver) {
 		for _, op := range ops {
 			drv.excludedOps[op] = struct{}{}
 		}

--- a/opts.go
+++ b/opts.go
@@ -1,8 +1,10 @@
 package sqltracing
 
+// Opt is a type for options that can be passed to NewDriver.
 type Opt func(*tracedDriver)
 
-// WithOpsExcluded defines operations for which no traces are recorded.
+// WithOpsExcluded can be passed as option to NewDriver.
+// It excludes recording traces for the passed database operations.
 func WithOpsExcluded(ops ...SQLOp) Opt {
 	return func(drv *tracedDriver) {
 		for _, op := range ops {

--- a/spans.go
+++ b/spans.go
@@ -7,7 +7,7 @@ import (
 
 const DBStatementTagKey = "db.statement"
 
-func (d *Driver) startSpan(ctx context.Context, opName SQLOp, query string, whitelistedErr ...error) (func(err error), context.Context) {
+func (d *tracedDriver) startSpan(ctx context.Context, opName SQLOp, query string, whitelistedErr ...error) (func(err error), context.Context) {
 	if d.opIsExcluded(opName) {
 		return func(_ error) {}, ctx
 	}

--- a/tracer.go
+++ b/tracer.go
@@ -2,7 +2,7 @@ package sqltracing
 
 import "context"
 
-// Tracer defines the required methods of a Tracer implementation
+// Tracer defines the required methods of a Tracer implementation.
 type Tracer interface {
 	// StartSpan extracts the parent span from ctx and starts a child span
 	// called spanName. It returns the child span and a new context that
@@ -10,7 +10,7 @@ type Tracer interface {
 	StartSpan(ctx context.Context, spanName string) (Span, context.Context)
 }
 
-// Span is part of the interface needed to be implemented by any tracing implementation we use
+// Span is part of the interface that needs to be implemented by Tracers.
 type Span interface {
 	// SetTag sets the tags with identifier k to value v.
 	SetTag(k, v string)

--- a/tracing/opentracing/tracer.go
+++ b/tracing/opentracing/tracer.go
@@ -1,3 +1,5 @@
+// package opentracing provides an opentracing-go Tracer that is compatible
+// with the sqltracing.Tracer interface.
 package opentracing
 
 import (
@@ -26,10 +28,11 @@ type span struct {
 	span opentracing.Span
 }
 
+// Opt is a type for options that can be passed to NewTracer.
 type Opt func(*tracer)
 
 // WithTracingTags is an option for NewTracer() to set the tags that are
-// applied to all traces.
+// applied to all traces created by StartSpan().
 func WithTracingTags(tags opentracing.Tags) Opt {
 	return func(t *tracer) {
 		t.defaultTags = tags
@@ -53,10 +56,8 @@ func WithTracer(fn func() opentracing.Tracer) Opt {
 }
 
 // NewTracer returns a tracer that will create spans via opentracing-go.
-// The following defaults are used for the configurable options:
-// - Tracer: opentracing.GlobalTracer
-// - Tags: DefaultTracingTags
-// - TraceOrphans: true
+// When no options are specified, opentracing.GlobalTracer is used as default
+// Tracer, DefaultTracingTags are used as tags and TraceOrphans is enabled.
 func NewTracer(opts ...Opt) sqltracing.Tracer {
 	tr := tracer{
 		traceOrphans: true,


### PR DESCRIPTION
```
        godoc: improve go documentation

-------------------------------------------------------------------------------
        make the Driver struct private

        sqltracing.Driver does not need to be public, rename it to tracedDriver
        and make it private.

```