### PR TITLE
stmt: record ExecContext, QueryContext calls on stmt child spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ See [example_test.go](example_test.go)
 
 ## Known Issues
 
-- Prepared Statements: `ExecContext()` and `QueryContext()` operations are
-  recorded as independent spans instead of as child spawns of the
-  `PrepareContext()` operation.
 - Transactions: all operations on transactions except `Commit()` and
   `Rollback()` are recorded as independent spans, instead of as child spans of
   the `BeginTx()` operation

--- a/driver_test.go
+++ b/driver_test.go
@@ -86,6 +86,7 @@ func assertIsParentSpanOp(t *testing.T, tracer *mocktracer.MockTracer, parentOp,
 }
 
 func assertIsParentSpan(t *testing.T, tracer *mocktracer.MockTracer, parentOp, childOp string) {
+	t.Helper()
 
 	parentSpan := findFinishedSpan(t, tracer, parentOp)
 	if parentSpan == nil {
@@ -246,12 +247,7 @@ func TestStatementExecContext(t *testing.T) {
 	_ = stmt.Close()
 
 	assertIsParentSpanOp(t, mockTracer, sqltracing.OpSQLPrepare, sqltracing.OpSQLStmtClose)
-	// TODO: this assert can be removed when the skip for
-	// StmtQueryIsChildSpan is removed
-	assertHasSpan(t, mockTracer, sqltracing.OpSQLStmtExec)
-
 	t.Run("StmtExecIsChildSpan", func(t *testing.T) {
-		t.Skip("not implemented")
 		assertIsParentSpanOp(t, mockTracer, sqltracing.OpSQLPrepare, sqltracing.OpSQLStmtExec)
 	})
 }
@@ -273,13 +269,7 @@ func TestStatementQueryContext(t *testing.T) {
 
 	assertIsParentSpanOp(t, mockTracer, sqltracing.OpSQLPrepare, sqltracing.OpSQLStmtClose)
 
-	// TODO: these both asserts can be removed when the skip for
-	// StmtQueryIsChildSpan is removed
-	assertHasSpan(t, mockTracer, sqltracing.OpSQLRowsNext)
-	assertHasSpan(t, mockTracer, sqltracing.OpSQLRowsClose)
-
 	t.Run("StmtQueryIsChildSpan", func(t *testing.T) {
-		t.Skip("not implemented")
 		assertIsParentSpanOp(t, mockTracer, sqltracing.OpSQLPrepare, sqltracing.OpSQLStmtQuery)
 		assertIsParentSpanOp(t, mockTracer, sqltracing.OpSQLStmtQuery, sqltracing.OpSQLRowsNext)
 		assertIsParentSpanOp(t, mockTracer, sqltracing.OpSQLStmtQuery, sqltracing.OpSQLRowsClose)

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/simplesurance/sqlmw v0.0.0-20210914161839-1b19ee35ec98 h1:EZdwxplglD/oMtbuvpL5tGwLgeoBXLQtoFb90VFuZmk=
-github.com/simplesurance/sqlmw v0.0.0-20210914161839-1b19ee35ec98/go.mod h1:Hm4eHnK/BDe+XH6qE4mxN5cCP+QjklGby5elQmW2rcQ=
 github.com/simplesurance/sqlmw v0.1.0 h1:0ISPClSiFcZYuvmO8wR45H0aGcEpcIrey6eB9tAzRR4=
 github.com/simplesurance/sqlmw v0.1.0/go.mod h1:Hm4eHnK/BDe+XH6qE4mxN5cCP+QjklGby5elQmW2rcQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Using simplesurance/sqlmw allows to access the tracedStmt that is returned by
PrepareContext() in StmtExecContext and StmtQueryContext.

This enables us to access the span of the PrepareContext
operations and  record StmtExecContext and StmtQueryContext as child
spans of PrepareContext instead of as separate spans.